### PR TITLE
Python 3.13 対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Alpine is not the best option. But it is good enough.
 FROM python:3.13.1-alpine3.21
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 COPY ./bot.py /application/bot.py
 COPY ./requirements.txt /application/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Alpine is not the best option. But it is good enough.
-FROM python:3.12.7-alpine3.20
+FROM python:3.13.1-alpine3.21
 
 ENV PYTHONUNBUFFERED 1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ google_api_python_client==2.156.0
 protobuf==5.29.2
 pytz==2024.2
 tweepy==4.14.0
+standard-imghdr==3.13.0


### PR DESCRIPTION
- tweepy が動かないので `standard-imghdr` を `requirements.txt` に追加
- Alpine Linux のバージョンを `3.21` に更新
- Dockerfile の `ENV` が非推奨の書式だったので修正